### PR TITLE
p2 .gitignore에 JPA Buddy 플러그인의 설정 파일을 무시하는 룰 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 tomcat.8080
 ### Querydsl Q파일 제외 ###
 **/generated
+### JPA Buddy 설정 파일 제외 ###
+**/.jpb/
 
 # Created by https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,visualstudiocode,windows,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=java,gradle,intellij+all,visualstudiocode,windows,macos


### PR DESCRIPTION
* IntelliJ 설정에서 jpa buddy(IntelliJ 플러그인) 설정을 바꾸면, 자동 생성되는 설정 파일이 프로젝트에 포함되지 않도록 파일 무시 규칙 추가