### PR TITLE
(수정)response DTO 코드 경미한 수정(Serializable 인터페이스 제거)

### DIFF
--- a/part2/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/response/ArticleCommentResponse.java
+++ b/part2/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.projectboard.response;
 
 import com.fastcampus.projectboard.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -11,7 +10,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/part2/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/response/ArticleResponse.java
+++ b/part2/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/response/ArticleResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.projectboard.response;
 
 import com.fastcampus.projectboard.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -13,7 +12,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/part2/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/response/ArticleWithCommentsResponse.java
+++ b/part2/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/response/ArticleWithCommentsResponse.java
@@ -2,7 +2,6 @@ package com.fastcampus.projectboard.response;
 
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);


### PR DESCRIPTION
ㅁJPA Buddy 를 이용해 작성한 DTO에 자동으로 `implements Serializable` 이 들어감
 ㅇ이 프로젝트는 직렬화로 Jackson을 사용하므로 필요하지 않고, 의도하여 넣은 코드도 아니므로 해당 부분 삭제