### PR TITLE
헤더에 해시태그 메뉴 추가하기

### DIFF
--- a/part2/fastcampus-project-board/src/main/resources/templates/header.html
+++ b/part2/fastcampus-project-board/src/main/resources/templates/header.html
@@ -11,7 +11,8 @@
         <div class="container">
             <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                    <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
                 </ul>
 
                 <div class="text-end">

--- a/part2/fastcampus-project-board/src/main/resources/templates/header.th.xml
+++ b/part2/fastcampus-project-board/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
ㅁ해시태그 메뉴를 헤더에 추가 - 링크는 타임리프 태그로 처리하도록 변경

This closes #47 .